### PR TITLE
Fixed Disallowed non-https on Maven repository starting from Jan 2020

### DIFF
--- a/dependencies/webview/build.gradle
+++ b/dependencies/webview/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
 		maven {
-			url "http://repo1.maven.org/maven2/"
+			url "https://repo1.maven.org/maven2/"
 		}
 	}
 	dependencies {


### PR DESCRIPTION
Requests to http://repo1.maven.org/maven2/ return a 501 HTTPS Required status.
Seems that, starting January 2020, the Maven repository no longer supports plain HTTP and requires that all requests are sent over HTTPS.